### PR TITLE
Add appointment types and variable durations

### DIFF
--- a/backend/appointment_types.json
+++ b/backend/appointment_types.json
@@ -1,0 +1,5 @@
+[
+  {"type": "Checkup", "duration_minutes": 30},
+  {"type": "Extended Visit", "duration_minutes": 60},
+  {"type": "Surgery Consultation", "duration_minutes": 45}
+]

--- a/backend/templates/booking.html
+++ b/backend/templates/booking.html
@@ -51,6 +51,14 @@
                             <label for="date" class="block text-sm font-medium text-slate-700">Appointment Date</label>
                             <input type="date" name="date" id="date" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
                         </div>
+                        <div>
+                            <label for="appointment_type" class="block text-sm font-medium text-slate-700">Appointment Type</label>
+                            <select name="appointment_type" id="appointment_type" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                {% for t in appointment_types %}
+                                <option value="{{ t['type'] }}">{{ t['type'] }} ({{ t['duration_minutes'] }} mins)</option>
+                                {% endfor %}
+                            </select>
+                        </div>
                         <div class="md:col-span-2">
                             <label for="reason" class="block text-sm font-medium text-slate-700">Reason for Visit</label>
                             <textarea name="reason" id="reason" rows="3" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" placeholder="e.g., Annual checkup, not eating, limping, anxious cat needs vaccinations...">My puppy is sick and throwing up.</textarea>

--- a/backend/templates/results.html
+++ b/backend/templates/results.html
@@ -15,6 +15,8 @@
                 <input type="hidden" name="pet_name" value="{{ pet_name }}">
                 <input type="hidden" name="reason" value="{{ reason }}">
                 <input type="hidden" name="date" value="{{ date }}">
+                <input type="hidden" name="appointment_type" value="{{ appointment_type }}">
+                <input type="hidden" name="duration_minutes" value="{{ duration_minutes }}">
                 <input type="hidden" name="time" value="{{ slot.start_time }}">
                 <input type="hidden" name="vet_id" value="{{ slot.vet_id }}">
                 <input type="hidden" name="room_id" value="{{ slot.room_id }}">


### PR DESCRIPTION
## Summary
- add `type` and `duration_minutes` to Appointment and load appointment types from JSON config
- expose appointment type selector in booking form and pass through booking flow
- respect variable appointment durations in OR-Tools solver

## Testing
- `python -m py_compile backend/api.py backend/scheduler/solver.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689122ee88a08331be2556d379c1c575