### PR TITLE
Add client contact details and reminder notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project showcases a veterinary clinic scheduling backend built with **Flask**.
 It includes a small HTML interface and uses SQLite for persistence.
 
+The application now stores client contact details and supports appointment
+reminders via email (SendGrid) and SMS (Twilio). Reminder preferences can be
+configured per client.
+
 ## Running with Docker
 
 Build and start the backend service:
@@ -12,4 +16,18 @@ docker-compose up --build
 ```
 
 The container seeds a demo database and launches the Flask app on [http://localhost:8000](http://localhost:8000).
+
+## Sending Reminder Notifications
+
+Reminders for the next day's appointments can be sent by running:
+
+```bash
+python backend/reminder_job.py
+```
+
+This script is suitable for execution via cron. Configure the following
+environment variables to enable notifications:
+
+- `SENDGRID_API_KEY` and `REMINDER_EMAIL` for email reminders.
+- `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` for SMS reminders.
 

--- a/backend/reminder_job.py
+++ b/backend/reminder_job.py
@@ -1,0 +1,31 @@
+"""Cron-friendly script to send upcoming appointment reminders."""
+from datetime import datetime, timedelta
+
+from api import Base, Session, Appointment, Client, engine
+from reminders import send_email_reminder, send_sms_reminder
+
+
+def main() -> None:
+    Base.metadata.create_all(engine)
+    session = Session()
+    try:
+        target_date = datetime.now().date() + timedelta(days=1)
+        appointments = session.query(Appointment).filter_by(date=target_date).all()
+        for appt in appointments:
+            client = session.query(Client).get(appt.client_id)
+            if not client:
+                continue
+            message = (
+                f"Reminder: appointment for {appt.pet_name} on {appt.date} at {appt.start_time}"
+            )
+            subject = "Appointment Reminder"
+            if client.email and client.email_opt_in:
+                send_email_reminder(client.email, subject, message)
+            if client.phone and client.sms_opt_in:
+                send_sms_reminder(client.phone, message)
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/reminders.py
+++ b/backend/reminders.py
@@ -1,0 +1,61 @@
+"""Utility functions for sending appointment reminders via email and SMS."""
+
+import os
+from typing import Optional
+
+
+def send_email_reminder(to_email: str, subject: str, body: str) -> None:
+    """Send an email reminder using SendGrid.
+
+    Requires the ``SENDGRID_API_KEY`` environment variable. If the
+    ``sendgrid`` package or API key is missing, the function will log to stdout
+    instead of raising an exception.
+    """
+    api_key = os.getenv("SENDGRID_API_KEY")
+    if not api_key:
+        print("SENDGRID_API_KEY not set; skipping email")
+        return
+    try:
+        from sendgrid import SendGridAPIClient
+        from sendgrid.helpers.mail import Mail
+    except Exception as exc:  # ImportError or other issues
+        print(f"SendGrid not available: {exc}")
+        return
+    message = Mail(
+        from_email=os.getenv("REMINDER_EMAIL", "noreply@example.com"),
+        to_emails=to_email,
+        subject=subject,
+        plain_text_content=body,
+    )
+    try:
+        sg = SendGridAPIClient(api_key)
+        sg.send(message)
+    except Exception as exc:  # pragma: no cover - network call
+        print(f"Error sending email: {exc}")
+
+
+def send_sms_reminder(to_phone: str, body: str) -> None:
+    """Send an SMS reminder using Twilio.
+
+    Requires ``TWILIO_SID``, ``TWILIO_AUTH_TOKEN``, and ``TWILIO_PHONE_NUMBER``
+    environment variables. Missing configuration results in a log message.
+    """
+    sid = os.getenv("TWILIO_SID")
+    token = os.getenv("TWILIO_AUTH_TOKEN")
+    from_phone = os.getenv("TWILIO_PHONE_NUMBER")
+    if not all([sid, token, from_phone]):
+        print("Twilio credentials not set; skipping SMS")
+        return
+    try:
+        from twilio.rest import Client as TwilioClient
+    except Exception as exc:
+        print(f"Twilio not available: {exc}")
+        return
+    try:  # pragma: no cover - network call
+        client = TwilioClient(sid, token)
+        client.messages.create(body=body, from_=from_phone, to=to_phone)
+    except Exception as exc:
+        print(f"Error sending SMS: {exc}")
+
+
+__all__ = ["send_email_reminder", "send_sms_reminder"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ fastapi==0.111.0
 uvicorn==0.30.0
 pydantic==2.7.4
 httpx==0.27.2
+sendgrid==6.10.0
+twilio==9.0.5

--- a/backend/templates/booking.html
+++ b/backend/templates/booking.html
@@ -44,6 +44,18 @@
                     hx-swap="innerHTML">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
+                            <label for="client_name" class="block text-sm font-medium text-slate-700">Your Name</label>
+                            <input type="text" name="client_name" id="client_name" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
+                            <label for="email" class="block text-sm font-medium text-slate-700">Email</label>
+                            <input type="email" name="email" id="email" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
+                            <label for="phone" class="block text-sm font-medium text-slate-700">Phone</label>
+                            <input type="tel" name="phone" id="phone" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
                             <label for="pet_name" class="block text-sm font-medium text-slate-700">Pet's Name</label>
                             <input type="text" name="pet_name" id="pet_name" required value="Buddy" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
                         </div>
@@ -55,6 +67,19 @@
                             <label for="reason" class="block text-sm font-medium text-slate-700">Reason for Visit</label>
                             <textarea name="reason" id="reason" rows="3" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" placeholder="e.g., Annual checkup, not eating, limping, anxious cat needs vaccinations...">My puppy is sick and throwing up.</textarea>
                             <p class="text-xs text-slate-400 mt-1">This text will be sent to the AI to help it choose the best time.</p>
+                        </div>
+                        <div class="md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-700">Reminder Preferences</label>
+                            <div class="mt-1">
+                                <label class="inline-flex items-center mr-4">
+                                    <input type="checkbox" name="email_opt_in" checked class="form-checkbox">
+                                    <span class="ml-2">Email</span>
+                                </label>
+                                <label class="inline-flex items-center">
+                                    <input type="checkbox" name="sms_opt_in" checked class="form-checkbox">
+                                    <span class="ml-2">SMS</span>
+                                </label>
+                            </div>
                         </div>
                     </div>
 

--- a/backend/templates/results.html
+++ b/backend/templates/results.html
@@ -18,6 +18,11 @@
                 <input type="hidden" name="time" value="{{ slot.start_time }}">
                 <input type="hidden" name="vet_id" value="{{ slot.vet_id }}">
                 <input type="hidden" name="room_id" value="{{ slot.room_id }}">
+                <input type="hidden" name="client_name" value="{{ client_name }}">
+                <input type="hidden" name="email" value="{{ email }}">
+                <input type="hidden" name="phone" value="{{ phone }}">
+                <input type="hidden" name="email_opt_in" value="{{ email_opt_in }}">
+                <input type="hidden" name="sms_opt_in" value="{{ sms_opt_in }}">
                 <button type="submit" class="px-4 py-2 bg-emerald-500 text-white text-sm font-medium rounded-md hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">
                     Book Appointment
                 </button>


### PR DESCRIPTION
## Summary
- add Client model with email/phone and opt-in fields
- support email/SMS reminders via SendGrid and Twilio
- include cron-friendly script to send reminders for upcoming appointments

## Testing
- `pytest`
- `python backend/reminder_job.py`


------
https://chatgpt.com/codex/tasks/task_e_689122f5db0c83318335e78805cbf9c5