### PR TITLE
Add client and patient management for appointments

### DIFF
--- a/backend/templates/booking.html
+++ b/backend/templates/booking.html
@@ -44,8 +44,13 @@
                     hx-swap="innerHTML">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
-                            <label for="pet_name" class="block text-sm font-medium text-slate-700">Pet's Name</label>
-                            <input type="text" name="pet_name" id="pet_name" required value="Buddy" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                            <label for="patient_id" class="block text-sm font-medium text-slate-700">Patient</label>
+                            <select name="patient_id" id="patient_id" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                {% for patient in patients %}
+                                <option value="{{ patient.id }}">{{ patient.name }} ({{ patient.client.name if patient.client else 'No Owner' }})</option>
+                                {% endfor %}
+                            </select>
+                            <a href="/patients/new" class="text-xs text-indigo-600">Add new patient</a>
                         </div>
                         <div>
                             <label for="date" class="block text-sm font-medium text-slate-700">Appointment Date</label>

--- a/backend/templates/clients/form.html
+++ b/backend/templates/clients/form.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ 'Edit' if client else 'New' }} Client</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">{{ 'Edit' if client else 'New' }} Client</h1>
+    <form method="post" class="space-y-4">
+        <div>
+            <label class="block mb-1">Name</label>
+            <input type="text" name="name" value="{{ client.name if client else '' }}" class="border p-2 w-full">
+        </div>
+        <div>
+            <label class="block mb-1">Phone</label>
+            <input type="text" name="phone" value="{{ client.phone if client else '' }}" class="border p-2 w-full">
+        </div>
+        <button type="submit" class="bg-indigo-600 text-white px-4 py-2">Save</button>
+    </form>
+</body>
+</html>

--- a/backend/templates/clients/list.html
+++ b/backend/templates/clients/list.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Clients</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Clients</h1>
+    <a href="/clients/new" class="text-indigo-600">Add Client</a>
+    <ul class="mt-4 space-y-2">
+        {% for client in clients %}
+        <li class="border p-2 flex justify-between items-center">
+            <span>{{ client.name }} ({{ client.phone }})</span>
+            <span>
+                <a href="/clients/{{ client.id }}/edit" class="text-indigo-600 mr-2">Edit</a>
+                <form action="/clients/{{ client.id }}/delete" method="post" class="inline">
+                    <button type="submit" class="text-red-600">Delete</button>
+                </form>
+            </span>
+        </li>
+        {% else %}
+        <li>No clients found.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/backend/templates/patients/form.html
+++ b/backend/templates/patients/form.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ 'Edit' if patient else 'New' }} Patient</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">{{ 'Edit' if patient else 'New' }} Patient</h1>
+    <form method="post" class="space-y-4">
+        <div>
+            <label class="block mb-1">Name</label>
+            <input type="text" name="name" value="{{ patient.name if patient else '' }}" class="border p-2 w-full">
+        </div>
+        <div>
+            <label class="block mb-1">Client</label>
+            <select name="client_id" class="border p-2 w-full">
+                {% for client in clients %}
+                <option value="{{ client.id }}" {% if patient and patient.client_id == client.id %}selected{% endif %}>{{ client.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="bg-indigo-600 text-white px-4 py-2">Save</button>
+    </form>
+</body>
+</html>

--- a/backend/templates/patients/list.html
+++ b/backend/templates/patients/list.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Patients</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Patients</h1>
+    <a href="/patients/new" class="text-indigo-600">Add Patient</a>
+    <ul class="mt-4 space-y-2">
+        {% for patient in patients %}
+        <li class="border p-2 flex justify-between items-center">
+            <span>{{ patient.name }} ({{ patient.client.name if patient.client else 'No Owner' }})</span>
+            <span>
+                <a href="/patients/{{ patient.id }}/edit" class="text-indigo-600 mr-2">Edit</a>
+                <form action="/patients/{{ patient.id }}/delete" method="post" class="inline">
+                    <button type="submit" class="text-red-600">Delete</button>
+                </form>
+            </span>
+        </li>
+        {% else %}
+        <li>No patients found.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/backend/templates/results.html
+++ b/backend/templates/results.html
@@ -12,7 +12,7 @@
         <div>
             <!-- This form will replace its parent div with the confirmation message from the server -->
             <form hx-post="/book-appointment" hx-target="closest div" hx-swap="outerHTML">
-                <input type="hidden" name="pet_name" value="{{ pet_name }}">
+                <input type="hidden" name="patient_id" value="{{ patient_id }}">
                 <input type="hidden" name="reason" value="{{ reason }}">
                 <input type="hidden" name="date" value="{{ date }}">
                 <input type="hidden" name="time" value="{{ slot.start_time }}">


### PR DESCRIPTION
## Summary
- add `Client` and `Patient` models and link appointments to patients
- implement CRUD routes and templates for managing clients and patients
- update booking flow to select existing patients when scheduling
- ensure patient queries eagerly load their client to avoid detached session issues

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689122ed875c8331a764318fea798613