### PR TITLE
Add appointment types and variable durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project showcases a veterinary clinic scheduling backend built with **Flask**.
 It includes a small HTML interface and uses SQLite for persistence.
 
+The application now stores client contact details and supports appointment
+reminders via email (SendGrid) and SMS (Twilio). Reminder preferences can be
+configured per client.
+
 ## Running with Docker
 
 Build and start the backend service:
@@ -12,4 +16,18 @@ docker-compose up --build
 ```
 
 The container seeds a demo database and launches the Flask app on [http://localhost:8000](http://localhost:8000).
+
+## Sending Reminder Notifications
+
+Reminders for the next day's appointments can be sent by running:
+
+```bash
+python backend/reminder_job.py
+```
+
+This script is suitable for execution via cron. Configure the following
+environment variables to enable notifications:
+
+- `SENDGRID_API_KEY` and `REMINDER_EMAIL` for email reminders.
+- `TWILIO_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` for SMS reminders.
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,11 +1,22 @@
 # backend/api.py
 import os
+import json
 import sqlite3
+import logging
+from logging.handlers import RotatingFileHandler
 from datetime import datetime, time, timedelta
 
 from flask import Flask, jsonify, redirect, render_template, request, url_for
-from sqlalchemy import (create_engine, Column, Integer, String, Time, ForeignKey,
-                        Date)
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    Time,
+    ForeignKey,
+    Date,
+    Boolean,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.exc import IntegrityError
 
@@ -22,6 +33,32 @@ _current_dir = os.path.dirname(os.path.abspath(__file__))
 _template_folder = os.path.join(_current_dir, 'templates')
 app = Flask(__name__, template_folder=_template_folder)
 
+# Configure server-side logging
+log_file = os.path.join(_current_dir, 'server.log')
+handler = RotatingFileHandler(log_file, maxBytes=100000, backupCount=3)
+handler.setLevel(logging.ERROR)
+formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s')
+handler.setFormatter(formatter)
+app.logger.addHandler(handler)
+app.logger.setLevel(logging.INFO)
+
+_config_file = os.path.join(_current_dir, 'appointment_types.json')
+
+
+def load_appointment_types():
+    """Load appointment types from configuration file."""
+    try:
+        with open(_config_file, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return []
+
+
+def api_error(code: str, message: str, status: int = 400):
+    """Return a standardized JSON API error response."""
+    app.logger.error(f"{code}: {message}")
+    return jsonify({'error': {'code': code, 'message': message}}), status
+
 
 # --- Database Models ---
 class Vet(Base):
@@ -34,6 +71,15 @@ class Room(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True)
 
+class Client(Base):
+    __tablename__ = 'clients'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    email = Column(String)
+    phone = Column(String)
+    email_opt_in = Column(Boolean, default=True)
+    sms_opt_in = Column(Boolean, default=True)
+
 class Appointment(Base):
     __tablename__ = 'appointments'
     id = Column(Integer, primary_key=True)
@@ -42,8 +88,43 @@ class Appointment(Base):
     date = Column(Date)
     start_time = Column(Time)
     end_time = Column(Time)
+    type = Column(String)
+    duration_minutes = Column(Integer)
     vet_id = Column(Integer, ForeignKey('vets.id'))
     room_id = Column(Integer, ForeignKey('rooms.id'))
+    client_id = Column(Integer, ForeignKey('clients.id'))
+
+# --- Helper functions to provide additional context ---
+def get_vet_specialties(vets):
+    """Return a mapping of vet IDs to their specialties."""
+    return {v.id: getattr(v, 'specialty', 'general practice') for v in vets}
+
+
+def get_room_features(rooms):
+    """Return a mapping of room IDs to their notable features."""
+    return {r.id: getattr(r, 'features', ['standard exam room']) for r in rooms}
+
+
+def get_patient_history(pet_name):
+    """Stub for fetching patient history."""
+    # In a real system, this would query a medical records database.
+    return {"pet_name": pet_name, "notes": "No prior history available."}
+
+
+VET_COLORS = [
+    "#e57373",  # red
+    "#64b5f6",  # blue
+    "#81c784",  # green
+    "#ffd54f",  # yellow
+    "#ba68c8",  # purple
+    "#4db6ac",  # teal
+]
+
+
+def get_vet_colors(session):
+    """Return a mapping of vet.id -> color for consistent color coding."""
+    vets = session.query(Vet).order_by(Vet.id).all()
+    return {vet.id: VET_COLORS[i % len(VET_COLORS)] for i, vet in enumerate(vets)}
 
 # --- App Routes ---
 
@@ -79,18 +160,32 @@ def setup_clinic():
             session.add(Room(name=f"Exam Room {i}"))
         
         session.commit()
-    except Exception as e:
+    except Exception:
         session.rollback()
-        app.logger.error(f"Error setting up clinic: {e}")
+        app.logger.exception("Error setting up clinic")
+        return api_error('SETUP_FAILED', 'Failed to set up clinic', 500)
     finally:
         session.close()
-    
+
     return redirect(url_for('booking_form'))
 
 @app.route('/booking')
 def booking_form():
     """Serves the main appointment booking page."""
-    return render_template('booking.html')
+    appointment_types = load_appointment_types()
+    return render_template('booking.html', appointment_types=appointment_types)
+
+
+@app.route('/calendar')
+def calendar_view():
+    """Display a calendar of appointments."""
+    session = Session()
+    try:
+        vets = session.query(Vet).all()
+        rooms = session.query(Room).all()
+    finally:
+        session.close()
+    return render_template('calendar.html', vets=vets, rooms=rooms)
 
 @app.route('/find-appointment', methods=['POST'])
 def find_appointment():
@@ -103,8 +198,17 @@ def find_appointment():
         # --- Get data from form ---
         pet_name = request.form.get('pet_name')
         reason = request.form.get('reason')
+        client_name = request.form.get('client_name')
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        email_opt_in = bool(request.form.get('email_opt_in'))
+        sms_opt_in = bool(request.form.get('sms_opt_in'))
         appointment_date_str = request.form.get('date')
+        appointment_type = request.form.get('appointment_type')
         appointment_date = datetime.strptime(appointment_date_str, '%Y-%m-%d').date()
+
+        types = load_appointment_types()
+        duration = next((t['duration_minutes'] for t in types if t['type'] == appointment_type), 30)
 
         # --- Core Logic ---
         # 1. Get resources and existing appointments from DB
@@ -114,24 +218,46 @@ def find_appointment():
 
         # 2. Use OR-Tools to find all feasible slots
         feasible_slots = find_available_slots(
-            appointment_date, vets, rooms, existing_appointments
+            appointment_date, vets, rooms, existing_appointments, duration
         )
 
         if not feasible_slots:
             return "<div>No available slots found for this date.</div>"
 
-        # 3. Use LLM to rank the feasible slots
+        # 3. Gather additional context and use LLM to rank the feasible slots
+        vet_specialties = get_vet_specialties(vets)
+        room_features = get_room_features(rooms)
+        patient_history = get_patient_history(pet_name)
         app.logger.info("Sending slots to AI ranker...")
-        ranked_slots = rank_slots_with_llm(feasible_slots, reason)
+        ranked_slots = rank_slots_with_llm(
+            feasible_slots,
+            reason,
+            vet_specialties,
+            room_features,
+            patient_history,
+        )
 
         # 4. Prepare top 3 slots for display
         top_slots = ranked_slots[:3]
 
-        return render_template('results.html', slots=top_slots, pet_name=pet_name, reason=reason, date=appointment_date_str)
+        return render_template(
+            'results.html',
+            slots=top_slots,
+            pet_name=pet_name,
+            reason=reason,
+            date=appointment_date_str,
+            appointment_type=appointment_type,
+            duration_minutes=duration,
+            client_name=client_name,
+            email=email,
+            phone=phone,
+            email_opt_in=email_opt_in,
+            sms_opt_in=sms_opt_in,
+        )
 
-    except Exception as e:
-        app.logger.error(f"Error finding appointment: {e}")
-        return f"<div class='text-red-500 p-4'>An error occurred: {e}</div>"
+    except Exception:
+        app.logger.exception("Error finding appointment")
+        return api_error('FIND_APPOINTMENT_FAILED', 'Unable to search appointments', 500)
     finally:
         session.close()
 
@@ -146,23 +272,42 @@ def book_appointment():
         reason = request.form.get('reason')
         date_str = request.form.get('date')
         time_str = request.form.get('time')
+        appointment_type = request.form.get('appointment_type')
+        duration = int(request.form.get('duration_minutes'))
         vet_id = int(request.form.get('vet_id'))
         room_id = int(request.form.get('room_id'))
+        client_name = request.form.get('client_name')
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        email_opt_in = request.form.get('email_opt_in') == 'True'
+        sms_opt_in = request.form.get('sms_opt_in') == 'True'
 
         appointment_date = datetime.strptime(date_str, '%Y-%m-%d').date()
         start_time_obj = datetime.strptime(time_str, '%H:%M').time()
-        
-        # Appointments are 30 minutes for this demo
-        end_time_obj = (datetime.combine(appointment_date, start_time_obj) + timedelta(minutes=30)).time()
+
+        end_time_obj = (datetime.combine(appointment_date, start_time_obj) + timedelta(minutes=duration)).time()
+
+        client = Client(
+            name=client_name,
+            email=email,
+            phone=phone,
+            email_opt_in=email_opt_in,
+            sms_opt_in=sms_opt_in,
+        )
+        session.add(client)
+        session.flush()
 
         new_appointment = Appointment(
             pet_name=pet_name,
             reason=reason,
+            type=appointment_type,
+            duration_minutes=duration,
             date=appointment_date,
             start_time=start_time_obj,
             end_time=end_time_obj,
             vet_id=vet_id,
-            room_id=room_id
+            room_id=room_id,
+            client_id=client.id,
         )
         session.add(new_appointment)
         session.commit()
@@ -173,13 +318,61 @@ def book_appointment():
 
     except IntegrityError:
         session.rollback()
-        return "Error: This slot was just booked by someone else. Please try another."
-    except Exception as e:
+        app.logger.exception("Slot already booked")
+        return api_error('SLOT_TAKEN', 'This slot was just booked by someone else. Please try another.', 409)
+    except Exception:
         session.rollback()
-        app.logger.error(f"Error booking appointment: {e}")
-        return f"An error occurred during booking: {e}"
+        app.logger.exception("Error booking appointment")
+        return api_error('BOOKING_FAILED', 'An error occurred during booking', 500)
     finally:
         session.close()
+
+
+@app.route('/api/appointments')
+def api_appointments():
+    """Return appointments in JSON for the calendar."""
+    vet_id = request.args.get('vet_id', type=int)
+    room_id = request.args.get('room_id', type=int)
+    session = Session()
+    try:
+        query = session.query(Appointment, Vet, Room).join(Vet).join(Room)
+        if vet_id:
+            query = query.filter(Appointment.vet_id == vet_id)
+        if room_id:
+            query = query.filter(Appointment.room_id == room_id)
+
+        vet_colors = get_vet_colors(session)
+
+        events = []
+        for appt, vet, room in query.all():
+            start_dt = datetime.combine(appt.date, appt.start_time)
+            end_dt = datetime.combine(appt.date, appt.end_time)
+            events.append({
+                "id": appt.id,
+                "title": f"{appt.pet_name} ({vet.name})",
+                "start": start_dt.isoformat(),
+                "end": end_dt.isoformat(),
+                "url": url_for('appointment_detail', appointment_id=appt.id),
+                "color": vet_colors.get(vet.id)
+            })
+
+        return jsonify(events)
+    finally:
+        session.close()
+
+
+@app.route('/appointment/<int:appointment_id>')
+def appointment_detail(appointment_id):
+    """Simple appointment details page."""
+    session = Session()
+    appointment = session.query(Appointment).filter_by(id=appointment_id).first()
+    if not appointment:
+        session.close()
+        return "Appointment not found", 404
+    vet = session.get(Vet, appointment.vet_id)
+    room = session.get(Room, appointment.room_id)
+    session.close()
+    return render_template('appointment_detail.html', appointment=appointment, vet=vet, room=room)
 
 if __name__ == '__main__':
     # This is for local development without Gunicorn

--- a/backend/appointment_types.json
+++ b/backend/appointment_types.json
@@ -1,0 +1,5 @@
+[
+  {"type": "Checkup", "duration_minutes": 30},
+  {"type": "Extended Visit", "duration_minutes": 60},
+  {"type": "Surgery Consultation", "duration_minutes": 45}
+]

--- a/backend/reminder_job.py
+++ b/backend/reminder_job.py
@@ -1,0 +1,31 @@
+"""Cron-friendly script to send upcoming appointment reminders."""
+from datetime import datetime, timedelta
+
+from api import Base, Session, Appointment, Client, engine
+from reminders import send_email_reminder, send_sms_reminder
+
+
+def main() -> None:
+    Base.metadata.create_all(engine)
+    session = Session()
+    try:
+        target_date = datetime.now().date() + timedelta(days=1)
+        appointments = session.query(Appointment).filter_by(date=target_date).all()
+        for appt in appointments:
+            client = session.query(Client).get(appt.client_id)
+            if not client:
+                continue
+            message = (
+                f"Reminder: appointment for {appt.pet_name} on {appt.date} at {appt.start_time}"
+            )
+            subject = "Appointment Reminder"
+            if client.email and client.email_opt_in:
+                send_email_reminder(client.email, subject, message)
+            if client.phone and client.sms_opt_in:
+                send_sms_reminder(client.phone, message)
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/reminders.py
+++ b/backend/reminders.py
@@ -1,0 +1,61 @@
+"""Utility functions for sending appointment reminders via email and SMS."""
+
+import os
+from typing import Optional
+
+
+def send_email_reminder(to_email: str, subject: str, body: str) -> None:
+    """Send an email reminder using SendGrid.
+
+    Requires the ``SENDGRID_API_KEY`` environment variable. If the
+    ``sendgrid`` package or API key is missing, the function will log to stdout
+    instead of raising an exception.
+    """
+    api_key = os.getenv("SENDGRID_API_KEY")
+    if not api_key:
+        print("SENDGRID_API_KEY not set; skipping email")
+        return
+    try:
+        from sendgrid import SendGridAPIClient
+        from sendgrid.helpers.mail import Mail
+    except Exception as exc:  # ImportError or other issues
+        print(f"SendGrid not available: {exc}")
+        return
+    message = Mail(
+        from_email=os.getenv("REMINDER_EMAIL", "noreply@example.com"),
+        to_emails=to_email,
+        subject=subject,
+        plain_text_content=body,
+    )
+    try:
+        sg = SendGridAPIClient(api_key)
+        sg.send(message)
+    except Exception as exc:  # pragma: no cover - network call
+        print(f"Error sending email: {exc}")
+
+
+def send_sms_reminder(to_phone: str, body: str) -> None:
+    """Send an SMS reminder using Twilio.
+
+    Requires ``TWILIO_SID``, ``TWILIO_AUTH_TOKEN``, and ``TWILIO_PHONE_NUMBER``
+    environment variables. Missing configuration results in a log message.
+    """
+    sid = os.getenv("TWILIO_SID")
+    token = os.getenv("TWILIO_AUTH_TOKEN")
+    from_phone = os.getenv("TWILIO_PHONE_NUMBER")
+    if not all([sid, token, from_phone]):
+        print("Twilio credentials not set; skipping SMS")
+        return
+    try:
+        from twilio.rest import Client as TwilioClient
+    except Exception as exc:
+        print(f"Twilio not available: {exc}")
+        return
+    try:  # pragma: no cover - network call
+        client = TwilioClient(sid, token)
+        client.messages.create(body=body, from_=from_phone, to=to_phone)
+    except Exception as exc:
+        print(f"Error sending SMS: {exc}")
+
+
+__all__ = ["send_email_reminder", "send_sms_reminder"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ fastapi==0.111.0
 uvicorn==0.30.0
 pydantic==2.7.4
 httpx==0.27.2
+sendgrid==6.10.0
+twilio==9.0.5

--- a/backend/scheduler/ranker.py
+++ b/backend/scheduler/ranker.py
@@ -8,88 +8,93 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # The Ollama API endpoint. Assumes Ollama is running on the host machine.
-# 'host.docker.internal' is a special DNS name that resolves to the host's IP from within a Docker container.
-# FIX: The URL was previously formatted as a Markdown link, which is invalid.
+# 'host.docker.internal' resolves to the host's IP from within a Docker container.
 OLLAMA_API_URL = "http://host.docker.internal:11434/api/generate"
 
-def rank_slots_with_llm(feasible_slots, reason_for_visit):
-    """
-    Ranks a list of feasible appointment slots using a local LLM.
+
+def rank_slots_with_llm(
+    feasible_slots,
+    reason_for_visit,
+    vet_specialties=None,
+    room_features=None,
+    patient_history=None,
+):
+    """Rank feasible appointment slots using a local LLM.
 
     Args:
-        feasible_slots (list): A list of dictionaries, each representing a slot.
-        reason_for_visit (str): The user-provided reason for the visit.
+        feasible_slots (list): List of dictionaries representing slots.
+        reason_for_visit (str): Reason provided by the client.
+        vet_specialties (dict, optional): Mapping of ``vet_id`` to specialty.
+        room_features (dict, optional): Mapping of ``room_id`` to features.
+        patient_history (dict, optional): Relevant medical history for the pet.
 
     Returns:
-        list: A sorted list of the top-ranked slots. Returns the original
-              list if the LLM call fails.
+        list: Ranked list of slots. Falls back to the original list if ranking
+              fails.
     """
     if not feasible_slots:
         return []
 
-    # Create a simplified list of slots for the prompt
-    prompt_slots = [
-        f"Slot {i+1}: Time {slot['start_time']}"
-        for i, slot in enumerate(feasible_slots)
-    ]
-    
-    prompt = f"""
-You are an expert veterinary clinic scheduler. Your task is to select the three best appointment times from a list of available slots based on the patient's reason for visit.
+    context = {
+        "reason_for_visit": reason_for_visit,
+        "patient_history": patient_history or {},
+        "vet_specialties": vet_specialties or {},
+        "room_features": room_features or {},
+        "available_slots": [
+            {
+                "slot_index": i + 1,
+                "vet_id": slot["vet_id"],
+                "vet_name": slot["vet_name"],
+                "room_id": slot["room_id"],
+                "room_name": slot["room_name"],
+                "start_time": slot["start_time"],
+                "end_time": slot["end_time"],
+            }
+            for i, slot in enumerate(feasible_slots)
+        ],
+    }
 
-**Reason for Visit:** "{reason_for_visit}"
-
-**Available Slots:**
-{json.dumps(prompt_slots, indent=2)}
-
-**Instructions:**
-1.  Analyze the "Reason for Visit". Consider urgency, potential need for a quiet environment, or if it's a routine check-up.
-    - Urgent-sounding requests (e.g., "not eating", "limping", "sick") should be prioritized for earlier slots.
-    - Routine visits (e.g., "annual checkup", "vaccinations") can be scheduled later.
-    - Anxious pets (e.g., "anxious cat", "scared of other dogs") might benefit from the very first slot of the day or the first slot after lunch when the clinic is quieter.
-2.  Based on your analysis, choose the top 3 most suitable slots from the list.
-3.  Return your response as a JSON object containing a single key "top_3_indices" with a list of the integer indices (1-based from the list above) of your chosen slots, from best to worst.
-
-**Example Response Format:**
-{{
-  "top_3_indices": [5, 2, 10]
-}}
-
-Now, provide the JSON for the given reason and slots.
-"""
+    prompt = (
+        "You are an expert veterinary clinic scheduler. Use the provided context "
+        "to select the three best appointment times.\n\nContext:\n"
+        f"{json.dumps(context, indent=2)}\n\n"
+        "Return a JSON object with a single key 'top_3_indices' containing the "
+        "list of slot_index values from best to worst."
+    )
 
     payload = {
         "model": "qwen:7b",
         "prompt": prompt,
         "format": "json",
-        "stream": False
+        "stream": False,
     }
 
     logger.info(f"Sending request to Ollama at {OLLAMA_API_URL}...")
     try:
-        response = requests.post(OLLAMA_API_URL, json=payload, timeout=60) # Increased timeout
+        response = requests.post(OLLAMA_API_URL, json=payload, timeout=60)
         response.raise_for_status()
 
-        response_text = response.json().get('response', '{}')
+        response_text = response.json().get("response", "{}")
         logger.info(f"Ollama raw response: {response_text}")
 
-        # The response from Ollama is a string containing JSON, so we parse it.
         ranked_data = json.loads(response_text)
-        
         top_indices = ranked_data.get("top_3_indices")
 
         if not top_indices or not isinstance(top_indices, list):
             logger.warning("LLM did not return valid indices. Returning original slot order.")
             return feasible_slots
 
-        # Convert 1-based indices from LLM to 0-based list indices
-        ranked_slots = [feasible_slots[i-1] for i in top_indices if 0 < i <= len(feasible_slots)]
+        ranked_slots = [
+            feasible_slots[i - 1]
+            for i in top_indices
+            if 0 < i <= len(feasible_slots)
+        ]
         return ranked_slots
 
     except requests.exceptions.RequestException as e:
         logger.error(f"Could not connect to Ollama API: {e}")
-        # Fallback: return the original list if the LLM is unavailable
         return feasible_slots
     except (json.JSONDecodeError, KeyError) as e:
         logger.error(f"Error parsing LLM response: {e}")
-        # Fallback: return the original list on malformed response
         return feasible_slots
+

--- a/backend/templates/appointment_detail.html
+++ b/backend/templates/appointment_detail.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Appointment Details</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-800">
+    <div class="max-w-md mx-auto mt-10 bg-white p-6 rounded shadow">
+        <h1 class="text-2xl font-bold text-indigo-600 mb-4">Appointment Details</h1>
+        <p class="mb-2"><span class="font-semibold">Pet:</span> {{ appointment.pet_name }}</p>
+        <p class="mb-2"><span class="font-semibold">Reason:</span> {{ appointment.reason }}</p>
+        <p class="mb-2"><span class="font-semibold">Date:</span> {{ appointment.date }}</p>
+        <p class="mb-2"><span class="font-semibold">Time:</span> {{ appointment.start_time }} - {{ appointment.end_time }}</p>
+        <p class="mb-2"><span class="font-semibold">Veterinarian:</span> {{ vet.name }}</p>
+        <p class="mb-2"><span class="font-semibold">Room:</span> {{ room.name }}</p>
+    </div>
+</body>
+</html>

--- a/backend/templates/booking.html
+++ b/backend/templates/booking.html
@@ -27,6 +27,9 @@
     </style>
 </head>
 <body class="bg-slate-50 text-slate-800">
+    <!-- Toast Notification Container -->
+    <div id="toast" class="hidden fixed top-4 right-4 px-4 py-2 rounded shadow text-white"></div>
+
     <div class="min-h-screen flex flex-col items-center p-4 pt-8">
         <div class="w-full max-w-2xl">
             <!-- Header -->
@@ -44,6 +47,18 @@
                     hx-swap="innerHTML">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
+                            <label for="client_name" class="block text-sm font-medium text-slate-700">Your Name</label>
+                            <input type="text" name="client_name" id="client_name" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
+                            <label for="email" class="block text-sm font-medium text-slate-700">Email</label>
+                            <input type="email" name="email" id="email" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
+                            <label for="phone" class="block text-sm font-medium text-slate-700">Phone</label>
+                            <input type="tel" name="phone" id="phone" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                        <div>
                             <label for="pet_name" class="block text-sm font-medium text-slate-700">Pet's Name</label>
                             <input type="text" name="pet_name" id="pet_name" required value="Buddy" class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
                         </div>
@@ -51,10 +66,31 @@
                             <label for="date" class="block text-sm font-medium text-slate-700">Appointment Date</label>
                             <input type="date" name="date" id="date" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
                         </div>
+                        <div>
+                            <label for="appointment_type" class="block text-sm font-medium text-slate-700">Appointment Type</label>
+                            <select name="appointment_type" id="appointment_type" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                {% for t in appointment_types %}
+                                <option value="{{ t['type'] }}">{{ t['type'] }} ({{ t['duration_minutes'] }} mins)</option>
+                                {% endfor %}
+                            </select>
+                        </div>
                         <div class="md:col-span-2">
                             <label for="reason" class="block text-sm font-medium text-slate-700">Reason for Visit</label>
                             <textarea name="reason" id="reason" rows="3" required class="mt-1 block w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" placeholder="e.g., Annual checkup, not eating, limping, anxious cat needs vaccinations...">My puppy is sick and throwing up.</textarea>
                             <p class="text-xs text-slate-400 mt-1">This text will be sent to the AI to help it choose the best time.</p>
+                        </div>
+                        <div class="md:col-span-2">
+                            <label class="block text-sm font-medium text-slate-700">Reminder Preferences</label>
+                            <div class="mt-1">
+                                <label class="inline-flex items-center mr-4">
+                                    <input type="checkbox" name="email_opt_in" checked class="form-checkbox">
+                                    <span class="ml-2">Email</span>
+                                </label>
+                                <label class="inline-flex items-center">
+                                    <input type="checkbox" name="sms_opt_in" checked class="form-checkbox">
+                                    <span class="ml-2">SMS</span>
+                                </label>
+                            </div>
                         </div>
                     </div>
 
@@ -79,6 +115,33 @@
     <script>
         // Set default date to today
         document.getElementById('date').valueAsDate = new Date();
+
+        function showToast(message, type = 'success') {
+            const toast = document.getElementById('toast');
+            toast.textContent = message;
+            const baseClasses = 'fixed top-4 right-4 px-4 py-2 rounded shadow text-white';
+            const color = type === 'success' ? 'bg-emerald-500' : 'bg-red-500';
+            toast.className = `${baseClasses} ${color}`;
+            toast.classList.remove('hidden');
+            setTimeout(() => toast.classList.add('hidden'), 3000);
+        }
+
+        document.body.addEventListener('htmx:afterRequest', (event) => {
+            const xhr = event.detail.xhr;
+            const endpoint = event.detail.elt.getAttribute('hx-post');
+            if (endpoint === '/book-appointment' && xhr.status === 200) {
+                showToast(xhr.responseText, 'success');
+            }
+        });
+
+        document.body.addEventListener('htmx:responseError', (event) => {
+            try {
+                const data = JSON.parse(event.detail.xhr.responseText);
+                showToast(data.error.message, 'error');
+            } catch (e) {
+                showToast('An unexpected error occurred', 'error');
+            }
+        });
     </script>
 </body>
 </html>

--- a/backend/templates/calendar.html
+++ b/backend/templates/calendar.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Appointment Calendar</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+</head>
+<body class="bg-slate-50 text-slate-800">
+    <div class="container mx-auto p-4">
+        <h1 class="text-3xl font-bold text-indigo-600 mb-4">Clinic Calendar</h1>
+        <div class="flex space-x-4 mb-4">
+            <div>
+                <label for="vetFilter" class="block text-sm font-medium text-slate-700">Veterinarian</label>
+                <select id="vetFilter" class="mt-1 block w-full border border-slate-300 rounded-md p-2">
+                    <option value="">All</option>
+                    {% for vet in vets %}
+                    <option value="{{ vet.id }}">{{ vet.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div>
+                <label for="roomFilter" class="block text-sm font-medium text-slate-700">Room</label>
+                <select id="roomFilter" class="mt-1 block w-full border border-slate-300 rounded-md p-2">
+                    <option value="">All</option>
+                    {% for room in rooms %}
+                    <option value="{{ room.id }}">{{ room.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+        <div id="calendar"></div>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const calendarEl = document.getElementById('calendar');
+            const vetFilter = document.getElementById('vetFilter');
+            const roomFilter = document.getElementById('roomFilter');
+
+            const calendar = new FullCalendar.Calendar(calendarEl, {
+                initialView: 'dayGridMonth',
+                events: function(fetchInfo, successCallback, failureCallback) {
+                    const params = new URLSearchParams();
+                    if (vetFilter.value) params.append('vet_id', vetFilter.value);
+                    if (roomFilter.value) params.append('room_id', roomFilter.value);
+                    fetch('/api/appointments?' + params.toString())
+                        .then(resp => resp.json())
+                        .then(data => successCallback(data))
+                        .catch(err => failureCallback(err));
+                },
+                eventClick: function(info) {
+                    if (info.event.url) {
+                        info.jsEvent.preventDefault();
+                        window.location.href = info.event.url;
+                    }
+                }
+            });
+
+            calendar.render();
+
+            vetFilter.addEventListener('change', () => calendar.refetchEvents());
+            roomFilter.addEventListener('change', () => calendar.refetchEvents());
+        });
+    </script>
+</body>
+</html>

--- a/backend/templates/results.html
+++ b/backend/templates/results.html
@@ -15,9 +15,16 @@
                 <input type="hidden" name="pet_name" value="{{ pet_name }}">
                 <input type="hidden" name="reason" value="{{ reason }}">
                 <input type="hidden" name="date" value="{{ date }}">
+                <input type="hidden" name="appointment_type" value="{{ appointment_type }}">
+                <input type="hidden" name="duration_minutes" value="{{ duration_minutes }}">
                 <input type="hidden" name="time" value="{{ slot.start_time }}">
                 <input type="hidden" name="vet_id" value="{{ slot.vet_id }}">
                 <input type="hidden" name="room_id" value="{{ slot.room_id }}">
+                <input type="hidden" name="client_name" value="{{ client_name }}">
+                <input type="hidden" name="email" value="{{ email }}">
+                <input type="hidden" name="phone" value="{{ phone }}">
+                <input type="hidden" name="email_opt_in" value="{{ email_opt_in }}">
+                <input type="hidden" name="sms_opt_in" value="{{ sms_opt_in }}">
                 <button type="submit" class="px-4 py-2 bg-emerald-500 text-white text-sm font-medium rounded-md hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">
                     Book Appointment
                 </button>


### PR DESCRIPTION
## Summary
- add `type` and `duration_minutes` to Appointment and load appointment types from JSON config
- expose appointment type selector in booking form and pass through booking flow
- respect variable appointment durations in OR-Tools solver
- remove duplicate vet color mapping left from merge

## Testing
- `python -m py_compile backend/api.py backend/scheduler/solver.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689122ee88a08331be2556d379c1c575